### PR TITLE
Snapyr Flutter iOS Integration for Event Ingestion

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
-import UIKit
 import Flutter
+import Snapyr
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,47 @@ import Flutter
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    let configuration = SnapyrConfiguration(writeKey: "iUP1MlMXSeilS20TUUavq5vygVI8mDMT")
+    configuration.snapyrEnvironment = SnapyrEnvironment.dev
+    configuration.trackApplicationLifecycleEvents = true
+    configuration.recordScreenViews = true
+    configuration.actionHandler = { msg in
+      print("Received Snapyr in-app message! \(msg)")
+    }
+    Snapyr.setup(with: configuration)
+
+    let controller: FlutterViewController = window?.rootViewController as! FlutterViewController
+    let snapyr_channel = FlutterMethodChannel(
+      name: "snapyr.com/data", binaryMessenger: controller.binaryMessenger)
+    snapyr_channel.setMethodCallHandler({
+      (_ call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+      if call.method == "identify" {
+        if let args = call.arguments as? [String: Any],
+          let uid = args["userId"] as? String,
+          let traits = args["traits"] as? [String: Any]
+        {
+          Snapyr.shared().identify(uid, traits: traits)
+        } else {
+          result(FlutterError.init(code: "bad args", message: nil, details: nil))
+        }
+
+      } else if call.method == "reset" {
+        Snapyr.shared().reset()
+      } else if call.method == "track" {
+        if let args = call.arguments as? [String: Any],
+          let event = args["event"] as? String,
+          let properties = args["properties"] as? [String: Any]
+        {
+          Snapyr.shared().track(event, properties: properties)
+          Snapyr.shared().flush()
+        } else {
+          result(FlutterError.init(code: "bad args", message: nil, details: nil))
+        }
+      }
+    }
+    )
+    // Snapyr.shared().identify("brian", traits: ["email": "bone@alumni.brown.edu"])
+    // Snapyr.shared().track("gamePlayed", properties: ["level": 1])
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,11 +1,17 @@
 import 'package:flappyBird/utils/bird_pos.dart';
 import 'package:flappyBird/views/home_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    identify("bonedog", {
+      'name': "brian",
+      'email': "bone@alumni.brown.edu",
+      'mobilePhone': "+12155886024"
+    });
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ChangeNotifierProvider(
@@ -14,4 +20,9 @@ class App extends StatelessWidget {
       ),
     );
   }
+}
+
+Future<void> identify(String userId, Map traits) async {
+  const platform = const MethodChannel('snapyr.com/data');
+  await platform.invokeMethod('identify', {'userId': userId, 'traits': traits});
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -7,11 +7,12 @@ import 'package:provider/provider.dart';
 class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    identify("bonedog", {
+    identify('bonedog', {
       'name': "brian",
       'email': "bone@alumni.brown.edu",
       'mobilePhone': "+12155886024"
     });
+    track('gamePlayed', {'level': 1});
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ChangeNotifierProvider(
@@ -25,4 +26,15 @@ class App extends StatelessWidget {
 Future<void> identify(String userId, Map traits) async {
   const platform = const MethodChannel('snapyr.com/data');
   await platform.invokeMethod('identify', {'userId': userId, 'traits': traits});
+}
+
+Future<void> track(String event, Map properties) async {
+  const platform = const MethodChannel('snapyr.com/data');
+  await platform
+      .invokeMethod('track', {'event': event, 'properties': properties});
+}
+
+Future<void> reset() async {
+  const platform = const MethodChannel('snapyr.com/data');
+  await platform.invokeMethod('reset');
 }


### PR DESCRIPTION

This pull requests shows how to create a bridge between the dart code and the native iOS SDK, which will allow you to send events to Snapyr directly from Flutter.